### PR TITLE
Redirect to corresponding logs (info to info, error to error), helps to work with other libraries like pm2 correctly

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -6,16 +6,16 @@ export const _success = (msg) => {
 };
 
 export const _info = (msg) => {
-  console.log(`%c${msg}`, `color:${COLORS.INFO};font-size: ${FONT_SIZE}; font-weight: ${FONT_WEIGHT}`);
+  console.info(`%c${msg}`, `color:${COLORS.INFO};font-size: ${FONT_SIZE}; font-weight: ${FONT_WEIGHT}`);
   return 'info';
 };
 
 export const _warning = (msg) => {
-  console.log(`%c${msg}`, `color:${COLORS.WARNING};font-size: ${FONT_SIZE}; font-weight: ${FONT_WEIGHT}`);
+  console.warn(`%c${msg}`, `color:${COLORS.WARNING};font-size: ${FONT_SIZE}; font-weight: ${FONT_WEIGHT}`);
   return 'warning';
 };
 
 export const _error = (msg) => {
-  console.log(`%c${msg}`, `color:${COLORS.ERROR};font-size: ${FONT_SIZE}; font-weight: ${FONT_WEIGHT}`);
+  console.error(`%c${msg}`, `color:${COLORS.ERROR};font-size: ${FONT_SIZE}; font-weight: ${FONT_WEIGHT}`);
   return 'error';
 };


### PR DESCRIPTION
Redirect to corresponding logs (info to info, error to error)
_info -> console.info
_error-> console.error

this helps to work with other libraries like pm2 correctly
